### PR TITLE
Add confirmation window

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If the `--erase` or `--reinstall` options are used, and additional packages are 
     ```
     sudo bash erase-install.sh --erase --extras=/path/containing/extra/packages
     ```
-* If both the `--erase` and `--confirm` options are used, a Jamf Helper confirmation dialog is displayed to the user prior to taking any action.
+* If both the `--erase` and `--confirm` options are used, a Jamf Helper window is displayed and the user is prompted to confirm erasure prior to taking any action. If the user chooses to cancel, the script will exit.
 
     ```
     sudo bash erase-install.sh --erase --confirm

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are a number of options that can be specified to automate this script furt
 2. `--reinstall` runs the `startosinstall` command to reinstall the system OS on the device (without the eraseinstall option). Use this for upgrade/reinstall without losing data.
 3. `--move` moved the macOS installer to `/Applications` or to a specified path if it isn't already there.
 4. `--overwrite` deletes any existing downloaded installer and re-downloads it.
+5. `--confirm` used with the `--erase` option, displays a Jamf Helper confirmation dialog to the user prior to taking any action.
 
 If the `--erase` or `--reinstall` options are used, and additional packages are placed in the folder specified by the variable `extra_installs`, which can be overridden with the `--extras` argument, these packages will be as part of the erase-/re-install process. These packages must be signed.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ There are a number of options that can be specified to automate this script furt
 2. `--reinstall` runs the `startosinstall` command to reinstall the system OS on the device (without the eraseinstall option). Use this for upgrade/reinstall without losing data.
 3. `--move` moved the macOS installer to `/Applications` or to a specified path if it isn't already there.
 4. `--overwrite` deletes any existing downloaded installer and re-downloads it.
-5. `--confirm` used with the `--erase` option, displays a Jamf Helper confirmation dialog to the user prior to taking any action.
 
 If the `--erase` or `--reinstall` options are used, and additional packages are placed in the folder specified by the variable `extra_installs`, which can be overridden with the `--extras` argument, these packages will be as part of the erase-/re-install process. These packages must be signed.
 
@@ -98,6 +97,11 @@ If the `--erase` or `--reinstall` options are used, and additional packages are 
 
     ```
     sudo bash erase-install.sh --erase --extras=/path/containing/extra/packages
+    ```
+* If both the `--erase` and `--confirm` options are used, a Jamf Helper confirmation dialog is displayed to the user prior to taking any action.
+
+    ```
+    sudo bash erase-install.sh --erase --confirm
     ```
 
 * Run with `--reinstall` argument to check and download the installer as required and then run it to reinstall macOS on the system volume. Can be used in conjunction with the `--os`, `--version`, `--build`, `--samebuild` and `--overwrite` flags.

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -298,7 +298,7 @@ reinstall="no"
 
 while test $# -gt 0
 do
-    case "$1" in
+    case "$4" in
         -l|--list) list="yes"
             ;;
         -e|--erase) erase="yes"
@@ -314,28 +314,28 @@ do
         --beta) beta="yes"
             ;;
         --seedprogram*)
-            seedprogram=$(echo $1 | sed -e 's|^[^=]*=||g')
+            seedprogram=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --catalogurl*)
-            catalogurl=$(echo $1 | sed -e 's|^[^=]*=||g')
+            catalogurl=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --path*)
-            installer_directory=$(echo $1 | sed -e 's|^[^=]*=||g')
+            installer_directory=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --extras*)
-            extras_directory=$(echo $1 | sed -e 's|^[^=]*=||g')
+            extras_directory=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --os*)
-            prechosen_os=$(echo $1 | sed -e 's|^[^=]*=||g')
+            prechosen_os=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --version*)
-            prechosen_version=$(echo $1 | sed -e 's|^[^=]*=||g')
+            prechosen_version=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --build*)
-            prechosen_build=$(echo $1 | sed -e 's|^[^=]*=||g')
+            prechosen_build=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         --workdir*)
-            workdir=$(echo $1 | sed -e 's|^[^=]*=||g')
+            workdir=$(echo $4 | sed -e 's|^[^=]*=||g')
             ;;
         -h|--help) show_help
             ;;

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -35,6 +35,9 @@ extras_directory="$workdir/extras"
 # Display downloading and erasing messages if this is running on Jamf Pro
 jamfHelper="/Library/Application Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper"
 
+# Icon to display in confirmation dialog
+confirmationIcon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/AlertStopIcon.icns"
+
 if [[ -f "$jamfHelper" ]]; then
     # Jamf Helper localizations - download window
     jh_dl_title_en="Downloading macOS"
@@ -345,6 +348,22 @@ done
 
 echo
 echo "   [erase-install] Script execution started: $(date)"
+
+# Make the user confirm they want to wipe their device
+if [[ $erase == "yes" ]]; then
+    confirmation=$("$jamfHelper" -windowType utility -lockHUD -title "Factory Reset" -alignHeading center -alignDescription natural -description "Are you sure you want to WIPE ALL DATA FROM THIS DEVICE and re-install macOS?" -button1 "Cancel" -button2 "Wipe/Reload" -icon "$confirmationIcon" -defaultButton 1 -cancelButton 1 2> /dev/null)
+    buttonClicked="${confirmation:$i-1}"
+
+    if [[ "$buttonClicked" == "0" ]]; then
+        echo "   [erase-install] User DECLINED erase/install"
+        exit 0
+    elif [[ "$buttonClicked" == "2" ]]; then
+        echo "   [erase-install] User CONFIRMED erase/install"
+    else
+        echo "   [erase-install] User FAILED to confirm erase/install"
+        exit 1
+    fi
+fi
 
 # ensure installer_directory exists
 /bin/mkdir -p "$installer_directory"


### PR DESCRIPTION
Adds the `--confirm` argument and associated functionality. When combined with the `--erase` argument, a Jamf Helper dialog window is displayed and the user must confirm the erasure before any action is taken.