### PR TITLE
Add forcequitapps install_args only when macOS 10.15 or greater

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -596,7 +596,7 @@ installer_os_version=$( echo "$installer_version" | sed 's|^10\.||' | sed 's|\..
 if [[ "$installer_os_version" == "12" ]]; then
     install_args+=("--applicationpath")
     install_args+=("$installmacOSApp")
-elif [[ "$installer_os_version" != "13" && "$installer_os_version" != "14" && "$installed_os_version" -ge "15" ]]; then
+elif [[ "$installed_os_version" -ge "15" ]]; then
     install_args+=("--forcequitapps")
 fi
 

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -596,8 +596,7 @@ installer_os_version=$( echo "$installer_version" | sed 's|^10\.||' | sed 's|\..
 if [[ "$installer_os_version" == "12" ]]; then
     install_args+=("--applicationpath")
     install_args+=("$installmacOSApp")
-elif [[ "$installer_os_version" != "13" && "$installer_os_version" != "14" ]]; then
-    # add forcequitapps option to 10.15 and above (haven't checked to see if it breaks the installer on older OS)
+elif [[ "$installer_os_version" != "13" && "$installer_os_version" != "14" && "${installed_os_version}" -ge "15" ]]; then
     install_args+=("--forcequitapps")
 fi
 

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -596,7 +596,7 @@ installer_os_version=$( echo "$installer_version" | sed 's|^10\.||' | sed 's|\..
 if [[ "$installer_os_version" == "12" ]]; then
     install_args+=("--applicationpath")
     install_args+=("$installmacOSApp")
-elif [[ "$installer_os_version" != "13" && "$installer_os_version" != "14" && "${installed_os_version}" -ge "15" ]]; then
+elif [[ "$installer_os_version" != "13" && "$installer_os_version" != "14" && "$installed_os_version" -ge "15" ]]; then
     install_args+=("--forcequitapps")
 fi
 


### PR DESCRIPTION
If you try to upgrade a 10.12 machine this argument gets added and stops the install process