### PR TITLE
Update erase-install.sh

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -793,6 +793,7 @@ run_installinstallmacos() {
     if ! python "$workdir/installinstallmacos.py" $installinstallmacos_args ; then
         echo "   [run_installinstallmacos] Error obtaining valid installer. Cannot continue."
         kill_process jamfHelper
+	kill_pricess DEPNotify
         echo
         exit 1
     fi

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -793,7 +793,7 @@ run_installinstallmacos() {
     if ! python "$workdir/installinstallmacos.py" $installinstallmacos_args ; then
         echo "   [run_installinstallmacos] Error obtaining valid installer. Cannot continue."
         kill_process jamfHelper
-	kill_pricess DEPNotify
+	    kill_process DEPNotify
         echo
         exit 1
     fi


### PR DESCRIPTION
Kill DEPNotify after an error, not only jamfHelper. When using DEPNotify and running into "[run_installinstallmacos] Error obtaining valid installer. Cannot continue.", the DEPNotify is not killed and the user is left with a running useless window.