### PR TITLE
Update SIP status check

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1354,7 +1354,7 @@ END
 fi
 
 # determine SIP status, as the volume is required if SIP is disabled
-/usr/bin/csrutil status | grep -q 'disabled' && sip="disabled" || sip="enabled"
+/usr/bin/csrutil status | sed -n 1p | grep -q 'disabled' && sip="disabled" || sip="enabled"
 
 # set install argument for erase option
 install_args=()


### PR DESCRIPTION
Update SIP check to only use first line otherwise the variable is filled with `disabled` when computer has a custom SIP configuration (see screenshot).
<img width="1052" alt="Screenshot 2021-07-26 at 23 09 15" src="https://user-images.githubusercontent.com/600317/127059727-6c61efc0-a92f-4d72-9635-721b5763e67d.png">
