### PR TITLE
changes to installinstallmacos.py download & checksumming

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -721,12 +721,6 @@ get_installinstallmacos() {
         mkdir -p "$workdir"
     fi
 
-    if [[ ! -f "$workdir/installinstallmacos_checksum" ]]; then
-	# make a checksumfile
-        echo $installinstallmacos_checksum > "$workdir/installinstallmacos_checksum"
-    fi
-
-
     if [[ ! -f "$workdir/installinstallmacos.py" || $force_installinstallmacos == "yes" ]]; then
         if [[ ! $no_curl ]]; then
             echo "   [get_installinstallmacos] Downloading installinstallmacos.py..."


### PR DESCRIPTION
- removed local checksum file creation
- change installinstallmacos.py download to use `curl -o` instead of `>` redirect, which causes issues when running with sudo
- fixed `shasum` comparison