### PR TITLE
Update installinstallmacos_checksum

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -46,7 +46,7 @@ exec > >(tee ${LOG_FILE}) 2>&1
 
 # URL for downloading installinstallmacos.py
 installinstallmacos_url="https://raw.githubusercontent.com/grahampugh/macadmin-scripts/master/installinstallmacos.py"
-installinstallmacos_checksum="f52fa78f7f51209de45fe1fb6ab0ce13f21b3008f129b4d17ab5b89b22b793c3"
+installinstallmacos_checksum="08ceb0187bd648e040c8ba23f79192f7d91b1250dbff47107c29cb2bca1ce433"
 
 # Directory in which to place the macOS installer. Overridden with --path
 installer_directory="/Applications"


### PR DESCRIPTION
Update installinstallmacos_checksum to match latest checksum of installinstallmacos_url.

Tested change on macOS 11.6 successfully