### PR TITLE
Fix: Download progress bar accuracy

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -669,7 +669,11 @@ dep_notify_progress() {
         done
         echo "Status: $dn_status - 0%" >> $depnotify_log
         echo "Command: DeterminateManual: 100" >> $depnotify_log
-
+        sleep 2
+        until [[ $current_progress_value -gt 0 && $current_progress_value -lt 100 ]]; do
+                current_progress_value=$(tail -1 $LOG_FILE | awk '{print substr($(NF-9), 1, length($NF))}')
+                sleep 2
+        done
         # Until at least 100% is reached, calculate the downloading progress and move the bar accordingly
         until [[ $current_progress_value -ge 100 ]]; do
             until [[ $current_progress_value -gt $last_progress_value ]]; do


### PR DESCRIPTION
installinstallmacos will download a few tiny files, which could falsely be interpreted by this function. The bar will show as complete before the actual download of the installer has even started.

Unverified attempt to address this edge case by letting it ignore the downloads of these tiny files and waiting a little longer until the calculation begins.