### PR TITLE
Include exit trap to ensure things are cleaned up appropriately

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -129,7 +129,7 @@ dialog_reinstall_heading_de="Bitte warten, das Upgrade macOS wird ausgeführt."
 dialog_reinstall_heading_nl="Even geduld terwijl we uw computer voorbereiden voor de upgrade van macOS."
 dialog_reinstall_heading_fr="Veuillez patienter pendant que nous préparons votre ordinateur pour la mise à niveau de macOS."
 
-dialog_reinstall_desc_en="This process may take up to 30 minutes. Once completed your computer will reboot and begin the upgrade."
+dialog_reinstall_desc_en="This process may take up to 30 minutes. Once completed your computer will reboot and complete the installation."
 dialog_reinstall_desc_de="Dieser Prozess benötigt bis zu 30 Minuten. Der Mac startet anschliessend neu und beginnt mit dem Update."
 dialog_reinstall_desc_nl="Dit proces duurt ongeveer 30 minuten. Zodra dit is voltooid, wordt uw computer opnieuw opgestart en begint de upgrade."
 dialog_reinstall_desc_fr="Ce processus peut prendre jusqu'à 30 minutes. Une fois terminé, votre ordinateur redémarrera et commencera la mise à niveau."
@@ -186,10 +186,10 @@ dialog_power_desc_nl="Sluit uw computer aan met de stroomadapter. Zodra deze is 
 dialog_power_desc_fr="Veuillez connecter votre ordinateur à un adaptateur secteur. Ce processus se poursuivra une fois que l'alimentation secteur sera détectée."
 
 # Dialogue localizations - ask for short name
-dialog_short_name_en="Please enter an account name to start the reinstallation process"
-dialog_short_name_de="Bitte geben Sie einen Kontonamen ein, um die Neuinstallation zu starten"
+dialog_short_name_en="Please enter an account name to start the installation process"
+dialog_short_name_de="Bitte geben Sie einen Kontonamen ein, um die Installation zu starten"
 dialog_short_name_nl="Voer een accountnaam in om het installatieproces te starten"
-dialog_short_name_fr="Veuillez entrer un nom de compte pour démarrer le processus de réinstallation"
+dialog_short_name_fr="Veuillez entrer un nom de compte pour démarrer le processus d'installation"
 
 # Dialogue localizations - ask for password
 dialog_not_volume_owner_en="account is not a Volume Owner! Please login using one of the following accounts and try again"
@@ -198,10 +198,10 @@ dialog_not_volume_owner_nl="Account is geen volume-eigenaar! Log in met een van 
 dialog_not_volume_owner_fr="le compte n'est pas propriétaire du volume ! Veuillez vous connecter en utilisant l'un des comptes suivants et réessayer"
 
 # Dialogue localizations - invalid user
-dialog_user_invalid_en="This account cannot be used to to perform the reinstall"
-dialog_user_invalid_de="Dieses Konto kann nicht zur Durchführung der Neuinstallation verwendet werden"
-dialog_user_invalid_nl="Dit account kan niet worden gebruikt om de herinstallatie uit te voeren"
-dialog_user_invalid_fr="Ce compte ne peut pas être utilisé pour effectuer la réinstallation"
+dialog_user_invalid_en="This account cannot be used to to perform the installation"
+dialog_user_invalid_de="Dieses Konto kann nicht zur Durchführung der Installation verwendet werden"
+dialog_user_invalid_nl="Dit account kan niet worden gebruikt om de installatie uit te voeren"
+dialog_user_invalid_fr="Ce compte ne peut pas être utilisé pour effectuer la installation"
 
 # Dialogue localizations - invalid password
 dialog_invalid_password_en="ERROR: The password entered is NOT the login password for"
@@ -305,7 +305,7 @@ check_installer_is_valid() {
     [[ -d "/Volumes/Shared Support" ]] && diskutil unmount force "/Volumes/Shared Support"
     # now attempt to mount
     if [[ -f "$existing_installer_app/Contents/SharedSupport/SharedSupport.dmg" ]]; then
-        if hdiutil attach -quiet -noverify "$existing_installer_app/Contents/SharedSupport/SharedSupport.dmg" ; then
+        if hdiutil attach -nobrowse -quiet -noverify "$existing_installer_app/Contents/SharedSupport/SharedSupport.dmg" ; then
             echo "   [check_installer_is_valid] Mounting $existing_installer_app/Contents/SharedSupport/SharedSupport.dmg"
             sleep 1
             build_xml="/Volumes/Shared Support/com_apple_MobileAsset_MacSoftwareUpdate/com_apple_MobileAsset_MacSoftwareUpdate.xml"
@@ -419,11 +419,11 @@ check_password() {
     # thanks to Dan Snelson for the idea
     user="$1"
     password="$2"
-	password_matches=$( /usr/bin/dscl /Search -authonly "$user" "$password" )
-	if [[ -z "${password_matches}" ]]; then
-		echo "   [check_password] Success: the password entered is the correct login password for $user."
-	else
-		echo "   [check_password] ERROR: The password entered is NOT the login password for $user."
+    password_matches=$( /usr/bin/dscl /Search -authonly "$user" "$password" )
+    if [[ -z "${password_matches}" ]]; then
+        echo "   [check_password] Success: the password entered is the correct login password for $user."
+    else
+        echo "   [check_password] ERROR: The password entered is NOT the login password for $user."
         # open_osascript_dialog syntax: title, message, button1, icon
         open_osascript_dialog "${!dialog_user_invalid}: $user" "" "OK" 2 &
         exit 1
@@ -669,7 +669,11 @@ dep_notify_progress() {
         done
         echo "Status: $dn_status - 0%" >> $depnotify_log
         echo "Command: DeterminateManual: 100" >> $depnotify_log
-
+        sleep 2
+        until [[ $current_progress_value -gt 0 && $current_progress_value -lt 100 ]]; do
+                current_progress_value=$(tail -1 $LOG_FILE | awk '{print substr($(NF-9), 1, length($NF))}')
+                sleep 2
+        done
         # Until at least 100% is reached, calculate the downloading progress and move the bar accordingly
         until [[ $current_progress_value -ge 100 ]]; do
             until [[ $current_progress_value -gt $last_progress_value ]]; do
@@ -1092,7 +1096,7 @@ run_installinstallmacos() {
     if ! "$python_path" "$workdir/installinstallmacos.py" "${installinstallmacos_args[@]}" ; then
         echo "   [run_installinstallmacos] Error obtaining valid installer. Cannot continue."
         kill_process jamfHelper
-	    kill_process DEPNotify
+        kill_process DEPNotify
         echo
         exit 1
     fi
@@ -1128,7 +1132,7 @@ run_installinstallmacos() {
     else
         echo "   [run_installinstallmacos] No disk image found. I guess nothing got downloaded."
         kill_process jamfHelper
-	    kill_process DEPNotify
+        kill_process DEPNotify
         exit 1
     fi
 }
@@ -1180,20 +1184,20 @@ swu_fetch_full_installer() {
                 if [[ $invalid_installer_found == "yes" ]]; then
                     echo "   [swu_fetch_full_installer] The downloaded app is invalid for this computer. Try with --version or without --fetch-full-installer"
                     kill_process jamfHelper
-            	    kill_process DEPNotify
+                    kill_process DEPNotify
                     exit 1
                 fi
             fi
         else
             echo "   [swu_fetch_full_installer] No install app found. I guess nothing got downloaded."
             kill_process jamfHelper
-    	    kill_process DEPNotify
+            kill_process DEPNotify
             exit 1
         fi
     else
         echo "   [swu_fetch_full_installer] softwareupdate --fetch-full-installer failed. Try without --fetch-full-installer option."
         kill_process jamfHelper
-	    kill_process DEPNotify
+        kill_process DEPNotify
         exit 1
     fi
 }
@@ -1358,6 +1362,24 @@ show_help() {
     "
     exit
 }
+
+finish() {
+    # kill caffeinate
+    kill_process "caffeinate"
+
+    # kill any dialogs if startosinstall ends before a reboot
+    kill_process "jamfHelper"
+    dep_notify_quit
+
+    # if we promoted the user then we should demote it again
+    if [[ $promoted_user ]]; then
+        /usr/sbin/dseditgroup -o edit -d "$promoted_user" admin
+        echo "     [$script_name] User $promoted_user was demoted back to standard user"
+    fi
+}
+
+# ensure the finish function is executed when exit is signaled
+trap "finish" EXIT
 
 
 ###############
@@ -1589,8 +1611,6 @@ elif [[ $invalid_installer_found == "yes" && ($pkg_installer && ! -f "$working_i
     rm -f "$working_macos_app"
     if [[ $clear_cache == "yes" ]]; then
         echo "   [$script_name] Quitting script as --clear-cache-only option was selected."
-        # kill caffeinate
-        kill_process "caffeinate"
         exit
     fi
 elif [[ $update_installer == "yes" && -d "$working_macos_app" && $overwrite != "yes" ]]; then
@@ -1601,8 +1621,6 @@ elif [[ $update_installer == "yes" && -d "$working_macos_app" && $overwrite != "
         overwrite_existing_installer
     elif [[ $clear_cache == "yes" ]]; then
         echo "   [$script_name] Quitting script as --clear-cache-only option was selected."
-        # kill caffeinate
-        kill_process "caffeinate"
         exit
     fi
 elif [[ $update_installer == "yes" && ($pkg_installer && -f "$working_installer_pkg") && $overwrite != "yes" ]]; then
@@ -1614,8 +1632,6 @@ elif [[ $update_installer == "yes" && ($pkg_installer && -f "$working_installer_
     fi
     if [[ $clear_cache == "yes" ]]; then
         echo "   [$script_name] Quitting script as --clear-cache-only option was selected."
-        # kill caffeinate
-        kill_process "caffeinate"
         exit
     fi
 elif [[ $overwrite == "yes" && -d "$working_macos_app" && ! $list ]]; then
@@ -1625,14 +1641,10 @@ elif [[ $overwrite == "yes" && ($pkg_installer && -f "$working_installer_pkg") &
     rm -f "$working_installer_pkg"
     if [[ $clear_cache == "yes" ]]; then
         echo "   [$script_name] Quitting script as --clear-cache-only option was selected."
-        # kill caffeinate
-        kill_process "caffeinate"
         exit
     fi
 elif [[ $invalid_installer_found == "yes" && ($erase == "yes" || $reinstall == "yes") && $skip_validation != "yes" ]]; then
     echo "   [$script_name] ERROR: Invalid installer is present. Run with --overwrite option to ensure that a valid installer is obtained."
-    # kill caffeinate
-    kill_process "caffeinate"
     exit 1
 fi
 
@@ -1644,8 +1656,6 @@ if [[ "$arch" == "arm64" && ($erase == "yes" || $reinstall == "yes") ]]; then
     if ! pgrep -q Finder ; then
         echo "    [$script_name] ERROR! The startosinstall binary requires a user to be logged in."
         echo
-        # kill caffeinate
-        kill_process "caffeinate"
         exit 1
     fi
     get_user_details
@@ -1742,8 +1752,6 @@ if [[ $erase != "yes" && $reinstall != "yes" ]]; then
     echo "   [$script_name] Cleaning working directory '$workdir/content'"
     rm -rf "$workdir/content"
 
-    # kill caffeinate
-    kill_process "caffeinate"
     echo
     exit
 fi
@@ -1758,8 +1766,6 @@ fi
 
 if [[ ! -d "$working_macos_app" ]]; then
     echo "   [$script_name] ERROR: Can't find the installer! "
-    # kill caffeinate
-    kill_process "caffeinate"
     exit 1
 fi
 [[ $erase == "yes" ]] && echo "   [$script_name] WARNING! Running $working_macos_app with eraseinstall option"
@@ -1907,17 +1913,4 @@ else
         echo "$working_macos_app/Contents/Resources/startosinstall" "${install_args[@]}" --pidtosignal $PID --pidtosignal $caffeinate_pid --agreetolicense --nointeraction "${install_package_list[@]}"
     fi
     sleep 120
-fi
-
-# kill any dialogs if startosinstall ends before a reboot
-kill_process "jamfHelper"
-dep_notify_quit
-
-# kill caffeinate
-kill_process "caffeinate"
-
-# if we get this far and we promoted the user then we should demote it again
-if [[ $promoted_user ]]; then
-    /usr/sbin/dseditgroup -o edit -d "$promoted_user" admin
-    echo "     [$script_name] User $promoted_user was demoted back to standard user"
 fi


### PR DESCRIPTION
This PR includes a potential fix for #146 where some clean-up tasks may not execute when exiting abnormally. Additionally, I've included the `-nobrowse` flag on line 308 to suppress the image volume from appearing on the desktop. This probably should not be seen by the end-user and could cause an issue if folks open it and leave it open in Finder.

@grahampugh Let me know if you see anything out of the ordinary or if we need to include anything else that can be safely cleaned up during the exit trap.