### PR TITLE
fix for not detecting the user language

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -929,7 +929,6 @@ get_user_details() {
 					break
 				fi
 				let "iCounter += 1"
-				sleep 1
 			done
 			# if needed, compare the RealName (which might contain spaces)
 			if [[ $user_is_volume_owner = 0 ]]; then

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -916,24 +916,24 @@ get_user_details() {
 			# Example:
 			# RecordNames for user are "John.Doe@pretendco.com" and "John.Doe", fdesetup
 			# says "John.Doe@pretendco.com", and account_shortname is "john.doe" or "Doe, John"
-			recordNameXML=$( /usr/bin/dscl -plist /Search -read Users/$user RecordName dsAttrTypeStandard:RecordName )
+			user_record_names_xml=$(/usr/bin/dscl -plist /Search -read Users/$user RecordName dsAttrTypeStandard:RecordName)
 			# loop through recordName array until error (we do not know the size of the array)
-			iCounter=0
+			record_name_index=0
 			while [[ :: ]]; do
-				recordName=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RecordName:${iCounter}" /dev/stdin 2>/dev/null <<< "$recordNameXML")
+				user_record_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RecordName:${record_name_index}" /dev/stdin 2>/dev/null <<< "$user_record_names_xml")
 				[[ $? -eq 0 ]] || break
-				if [[ "$account_shortname" == "$recordName" ]]; then
+				if [[ "$account_shortname" == "$user_record_name" ]]; then
 					account_shortname=$user
 					echo "   [get_user_details] $account_shortname is a Volume Owner"
 					user_is_volume_owner=1
 					break
 				fi
-				let "iCounter += 1"
+				record_name_index=$((record_name_index+1))
 			done
 			# if needed, compare the RealName (which might contain spaces)
 			if [[ $user_is_volume_owner = 0 ]]; then
-				realName=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RealName:0" /dev/stdin <<< "$(/usr/bin/dscl -plist /Search -read Users/$user RealName)")
-				if [[ "$account_shortname" == "$realName" ]]; then
+				user_real_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RealName:0" /dev/stdin <<< "$(/usr/bin/dscl -plist /Search -read Users/$user RealName)")
+				if [[ "$account_shortname" == "$user_real_name" ]]; then
 					account_shortname=$user
 					echo "   [get_user_details] $account_shortname is a Volume Owner"
 					user_is_volume_owner=1

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -74,7 +74,9 @@ catalogurl="https://swscan.apple.com/content/catalogs/others/index-12-10.16-10.1
 
 # Grab currently logged in user to set the language for Dialogue messages
 current_user=$(/usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk -F': ' '/[[:space:]]+Name[[:space:]]:/ { if ( $2 != "loginwindow" ) { print $2 }}')
-language=$(/usr/libexec/PlistBuddy -c 'print AppleLanguages:0' "/Users/${current_user}/Library/Preferences/.GlobalPreferences.plist")
+# Get proper home directory. Output of scutil might not reflect the canonical RecordName or the HomeDirectory at all, which might prevent us from detecting the language
+current_user_homedir=$(/usr/bin/dscl /Search -read /Users/${current_user} NFSHomeDirectory | /usr/bin/awk -F': ' '{print $2}')
+language=$(/usr/libexec/PlistBuddy -c 'print AppleLanguages:0' "/${current_user_homedir}/Library/Preferences/.GlobalPreferences.plist")
 if [[ $language = de* ]]; then
     user_language="de"
 elif [[ $language = nl* ]]; then


### PR DESCRIPTION
Another side effect of the RecordName ambiguity: RecordName and HomeDir do not necessary match. By explicitly getting the NFSHomeDirectory attribute, we can get the real path to the user's home directory and then safely read the current AppleLanguages setting.

Otherwise we could see a PlistBuddy error message in the log and would default to english even the OS language was set to german.