### PR TITLE
[Fix] free space fallback for unattended install

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -281,7 +281,7 @@ check_free_space() {
     # determine if the amount of free and purgable drive space is sufficient for the upgrade to take place.
     free_disk_space=$(osascript -l 'JavaScript' -e "ObjC.import('Foundation'); var freeSpaceBytesRef=Ref(); $.NSURL.fileURLWithPath('/').getResourceValueForKeyError(freeSpaceBytesRef, 'NSURLVolumeAvailableCapacityForImportantUsageKey', null); Math.round(ObjC.unwrap(freeSpaceBytesRef[0]) / 1000000000)")  # with thanks to Pico
 
-    if [[ ! "$free_disk_space" ]]; then
+    if [[ -z "$current_user" ]]; then
         # fall back to df -h if the above fails
         free_disk_space=$(df -Pk . | column -t | sed 1d | awk '{print $4}')
     fi


### PR DESCRIPTION
This is a PR to fix the current fallback for the free_disk_space() function during unattended installs. 

Fixes issue #206 