### PR TITLE
Addresses Issue #208 and improves handling of wrong passwords 

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1768,6 +1768,12 @@ while test $# -gt 0 ; do
         --user*)
             account_shortname=$(echo "$1" | sed -e 's|^[^=]*=||g')
             ;;
+        --max-password-attempts*)
+            new_max_password_attempts=$(echo "$1" | sed -e 's|^[^=]*=||g')
+            if [[ ( $new_max_password_attempts == "infinite" ) || ( $new_max_password_attempts -gt 0 ) ]]; then
+                max_password_attempts="$1"
+            fi
+            ;;
         --rebootdelay*)
             rebootdelay=$(echo "$1" | sed -e 's|^[^=]*=||g')
             if [[ $rebootdelay -gt 300 ]]; then

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1477,7 +1477,7 @@ show_help() {
     --user XYZ          Supply a user with which to authenticate startosinstall
     --max-password-attempts NN | infinite
                         Overrides the default of 5 attempts to ask for the user's password. Using
-                        "infinite" will disable the Cancel button and asking until the password is
+                        'infinite' will disable the Cancel button and asking until the password is
                         successfully verified.
 
     Experimental features for macOS 10.15+:

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1039,9 +1039,10 @@ get_user_details() {
     fi
 
     # get password and check that the password is correct
-    password_attempts=0
+    password_attempts=1
     password_check="fail"
     while [[ "$password_check" != "pass" ]] ; do
+        echo "   [get_user_details] ask for password (attempt $password_attempts/$max_password_attempts)"
         account_password=$(ask_for_password)
         ask_for_password_rc=$?
         # prevent accidental cancelling by simply pressing return (entering an empty password)
@@ -1051,12 +1052,12 @@ get_user_details() {
         fi
         check_password "$account_shortname" "$account_password"
 
-        password_attempts=$((password_attempts+1))
         if [[ ( $max_password_attempts != "infinite" ) && ( $password_attempts -ge $max_password_attempts ) ]]; then
             # open_osascript_dialog syntax: title, message, button1, icon
             open_osascript_dialog "${!dialog_invalid_password}: $user" "" "OK" 2 
             exit 1
         fi
+        password_attempts=$((password_attempts+1))
     done
 
     # if we are performing eraseinstall the user needs to be an admin so let's promote the user
@@ -1651,8 +1652,9 @@ while test $# -gt 0 ; do
             ;;
         --max-password-attempts)
             shift
-            max_password_attempts="$1"
-            echo "set max_password_attempts to $max_password_attempts"
+            if [[ ( $1 == "infinity" ) || ( $1 -gt 0 ) ]]; then
+                max_password_attempts="$1"
+            fi
             ;;
         --rebootdelay)
             shift

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1475,9 +1475,9 @@ show_help() {
       this script cannot be run at the login window or from remote terminal.
     --current-user      Authenticate startosinstall using the current user
     --user XYZ          Supply a user with which to authenticate startosinstall
-    --max-password-attempts NN | infinity
+    --max-password-attempts NN | infinite
                         Overrides the default of 5 attempts to ask for the user's password. Using
-                        "infinity" will disable the Cancel button and asking until the password is
+                        "infinite" will disable the Cancel button and asking until the password is
                         successfully verified.
 
     Experimental features for macOS 10.15+:
@@ -1652,7 +1652,7 @@ while test $# -gt 0 ; do
             ;;
         --max-password-attempts)
             shift
-            if [[ ( $1 == "infinity" ) || ( $1 -gt 0 ) ]]; then
+            if [[ ( $1 == "infinite" ) || ( $1 -gt 0 ) ]]; then
                 max_password_attempts="$1"
             fi
             ;;


### PR DESCRIPTION
- Added option --max-password-attempts, which can either be a number or a literal "infinity" (to prevent canceling the password entry dialog)
- Fixes accidental canceling of the password entry dialog (by pressing enter, which supplies an empty password)
- Removes erroneous dialogs when password is not correct ("This user cannot be used to…")
- Shows the proper "password is not correct" message after unsuccessful checking cycle
- Plays the "Basso" sound when password is wrong