### PR TITLE
Small updates to german localization

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -132,19 +132,19 @@ dialog_rebooting_heading_nl="De upgrade is nu klaar voor installatie. Sla uw wer
 dialog_rebooting_heading_fr="La mise à niveau est maintenant prête à être installée. Veuillez sauvegarder votre travail!"
 
 dialog_rebooting_status_en="Preparation complete - restarting in"
-dialog_rebooting_status_de="Vorbereitung abgeschlossen - Neustart in "
+dialog_rebooting_status_de="Vorbereitung abgeschlossen - Neustart in"
 dialog_rebooting_status_nl="Voorbereiding compleet - herstart over"
 dialog_rebooting_status_fr="Préparation terminée - redémarrage dans"
 
 # Dialogue localizations - confirmation window (erase)
 dialog_erase_confirmation_desc_en="Please confirm that you want to ERASE ALL DATA FROM THIS DEVICE and reinstall macOS"
-dialog_erase_confirmation_desc_de="Bitte bestätigen Sie, dass Sie ALLE DATEN VON DIESEM GERÄT LÖSCHEN und macOS neu installieren wollen"
+dialog_erase_confirmation_desc_de="Bitte bestätigen Sie, dass Sie ALLE DATEN VON DIESEM GERÄT LÖSCHEN und macOS neu installieren wollen!"
 dialog_erase_confirmation_desc_nl="Weet je zeker dat je ALLE GEGEVENS VAN DIT APPARAAT WILT WISSEN en macOS opnieuw installeert?"
 dialog_erase_confirmation_desc_fr="Veuillez confirmer que vous souhaitez EFFACER TOUTES LES DONNÉES DE CET APPAREIL et réinstaller macOS"
 
 # Dialogue localizations - confirmation window (reinstall)
 dialog_reinstall_confirmation_desc_en="Please confirm that you want to upgrade macOS on this system now"
-dialog_reinstall_confirmation_desc_de="Bitte bestätigen Sie, dass Sie macOS auf diesem System jetzt aktualisieren möchten"
+dialog_reinstall_confirmation_desc_de="Bitte bestätigen Sie, dass Sie macOS auf diesem System jetzt aktualisieren möchten."
 dialog_reinstall_confirmation_desc_nl="Bevestig dat u macOS op dit systeem nu wilt updaten"
 dialog_reinstall_confirmation_desc_fr="Veuillez confirmer que vous voulez mettre à jour macOS sur ce système maintenant."
 

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -90,7 +90,7 @@ dialog_dl_title_nl="macOS downloaden"
 dialog_dl_title_fr="Téléchargement de macOS"
 
 dialog_dl_desc_en="We need to download the macOS installer to your computer; this will take several minutes."
-dialog_dl_desc_de="Der macOS Installer wird heruntergeladen, dies dauert mehrere Minuten."
+dialog_dl_desc_de="Das macOS-Installationsprogramm wird heruntergeladen; dies kann einige Minuten dauern."
 dialog_dl_desc_nl="We moeten het macOS besturingssysteem downloaden, dit duurt enkele minuten."
 dialog_dl_desc_fr="Nous devons télécharger le programme d'installation de macOS sur votre ordinateur, cela prendra plusieurs minutes."
 
@@ -101,23 +101,23 @@ dialog_erase_title_nl="macOS herinstalleren"
 dialog_erase_title_fr="Effacement de macOS"
 
 dialog_erase_desc_en="Preparing the installer may take up to 30 minutes. Once completed your computer will reboot and continue the reinstallation."
-dialog_erase_desc_de="Das Vorbereiten des Installationsprogramms kann bis zu 30 Minuten dauern. Nach Abschluss wird Ihr Computer neu gestartet und die Neuinstallation fortgesetzt."
+dialog_erase_desc_de="Das Vorbereiten der Installation kann bis zu 30 Minuten dauern. Danach wird der Computer neu gestartet und die Neuinstallation fortgesetzt."
 dialog_erase_desc_nl="Het voorbereiden van het installatieprogramma kan tot 30 minuten duren. Zodra het proces is voltooid, wordt uw computer opnieuw opgestart en wordt de herinstallatie voortgezet."
 dialog_erase_desc_fr="La préparation de l'installation peut prendre jusqu'à 30 minutes. Une fois terminée, votre ordinateur redémarrera et poursuivra la réinstallation."
 
 # Dialogue localizations - reinstall lockscreen
 dialog_reinstall_title_en="Upgrading macOS"
-dialog_reinstall_title_de="Upgrading macOS"
+dialog_reinstall_title_de="macOS aktualisieren"
 dialog_reinstall_title_nl="macOS upgraden"
 dialog_reinstall_title_fr="Mise à niveau de macOS"
 
 dialog_reinstall_heading_en="Please wait as we prepare your computer for upgrading macOS."
-dialog_reinstall_heading_de="Bitte warten, das Upgrade macOS wird ausgeführt."
+dialog_reinstall_heading_de="Die macOS-Aktualisierung wird vorbereitet."
 dialog_reinstall_heading_nl="Even geduld terwijl we uw computer voorbereiden voor de upgrade van macOS."
 dialog_reinstall_heading_fr="Veuillez patienter pendant que nous préparons votre ordinateur pour la mise à niveau de macOS."
 
 dialog_reinstall_desc_en="This process may take up to 30 minutes. Once completed your computer will reboot and begin the upgrade."
-dialog_reinstall_desc_de="Dieser Prozess benötigt bis zu 30 Minuten. Der Mac startet anschliessend neu und beginnt mit dem Update."
+dialog_reinstall_desc_de="Dieser Prozess kann bis zu 30 Minuten benötigen. Der Computer startet anschliessend neu und beginnt mit der Aktualisierung."
 dialog_reinstall_desc_nl="Dit proces duurt ongeveer 30 minuten. Zodra dit is voltooid, wordt uw computer opnieuw opgestart en begint de upgrade."
 dialog_reinstall_desc_fr="Ce processus peut prendre jusqu'à 30 minutes. Une fois terminé, votre ordinateur redémarrera et commencera la mise à niveau."
 
@@ -127,7 +127,7 @@ dialog_reinstall_status_nl="MacOS voorbereiden voor installatie"
 dialog_reinstall_status_fr="Préparation de macOS pour l'installation"
 
 dialog_rebooting_heading_en="The upgrade is now ready for installation. Please save your work!"
-dialog_rebooting_heading_de="Das Upgrade ist nun bereit für die Installation. Bitte speichern Sie Ihre Arbeit!"
+dialog_rebooting_heading_de="Das macOS-Aktualisierung steht nun zur Installation bereit. Bitte sichern Sie Ihre Arbeit!"
 dialog_rebooting_heading_nl="De upgrade is nu klaar voor installatie. Sla uw werk op!"
 dialog_rebooting_heading_fr="La mise à niveau est maintenant prête à être installée. Veuillez sauvegarder votre travail!"
 
@@ -138,7 +138,7 @@ dialog_rebooting_status_fr="Préparation terminée - redémarrage dans"
 
 # Dialogue localizations - confirmation window (erase)
 dialog_erase_confirmation_desc_en="Please confirm that you want to ERASE ALL DATA FROM THIS DEVICE and reinstall macOS"
-dialog_erase_confirmation_desc_de="Bitte bestätigen, dass Sie ALLE DATEN VON DIESEM GERÄT LÖSCHEN und macOS neu installieren wollen"
+dialog_erase_confirmation_desc_de="Bitte bestätigen Sie, dass Sie ALLE DATEN VON DIESEM GERÄT LÖSCHEN und macOS neu installieren wollen"
 dialog_erase_confirmation_desc_nl="Weet je zeker dat je ALLE GEGEVENS VAN DIT APPARAAT WILT WISSEN en macOS opnieuw installeert?"
 dialog_erase_confirmation_desc_fr="Veuillez confirmer que vous souhaitez EFFACER TOUTES LES DONNÉES DE CET APPAREIL et réinstaller macOS"
 
@@ -172,18 +172,18 @@ dialog_enter_button_fr="Entrer"
 
 # Dialogue localizations - free space check
 dialog_check_desc_en="The macOS upgrade cannot be installed as there is not enough space left on the drive."
-dialog_check_desc_de="Das Upgrade von macOS kann nicht installiert werden, da nicht genügend Speicherplatz auf dem Laufwerk vorhanden ist."
+dialog_check_desc_de="macOS kann nicht aktualisiert werden, da nicht genügend Speicherplatz auf dem Laufwerk frei ist."
 dialog_check_desc_nl="De upgrade van macOS kan niet worden geïnstalleerd omdat er niet genoeg ruimte is op de schijf."
 dialog_check_desc_fr="La mise à niveau de macOS ne peut pas être installée car il n'y a pas assez d'espace disponible sur ce volume."
 
 # Dialogue localizations - power check
 dialog_power_title_en="Waiting for AC Power Connection"
-dialog_power_title_de="Warten auf AC-Netzteil"
+dialog_power_title_de="Auf Netzteil warten"
 dialog_power_title_nl="Wachten op stroomadapter"
 dialog_power_title_fr="En attente de l'alimentation secteur"
 
 dialog_power_desc_en="Please connect your computer to power using an AC power adapter. This process will continue if AC power is detected within the next:"
-dialog_power_desc_de="Bitte schließen Sie Ihren Computer mit einem AC-Netzteil an das Stromnetz an. Dieser Prozess wird fortgesetzt, sobald die AC-Stromversorgung innerhalb der folgende Zeitdauer erkannt wird:"
+dialog_power_desc_de="Bitte verbinden Sie Ihren Computer mit einem Netzteil. Dieser Prozess wird fortgesetzt, wenn eine Stromversorgung innerhalb der folgenden Zeit erkannt wird:"
 dialog_power_desc_nl="Sluit uw computer aan met de stroomadapter. Zodra deze is gedetecteerd gaat het proces verder binnen de volgende:"
 dialog_power_desc_fr="Veuillez connecter votre ordinateur à un adaptateur secteur. Ce processus se poursuivra une fois que l'alimentation secteur sera détectée dans la suivante:"
 


### PR DESCRIPTION
This is done mainly because someone asked me to change the text "macOS upgrade" to "macOS update". This would be the subtle difference between staying in the same major revision or upgrading to another major version. This would of course require some code comparing OS versions.
But instead of that i decided to just to do it like apple: forget about subtle differences and use the same wording the software update preference pane uses: "Aktualisierung" (which is vague enough to cover both cases).

Also some other small changes, like conform "save" to Apple's translations ("sichern" instead of "speichern") and remove redundant "AC" from "Netzteil".