### PR TITLE
Reorder Dialog Buttons to conform to Apple HID

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -291,7 +291,6 @@ check_free_space() {
         # fall back to df -h if the above fails
         free_disk_space=$(df -Pk . | column -t | sed 1d | awk '{print $4}')
     fi
-        echo "   [check_free_space] min_drive_space: $free_disk_space vs $min_drive_space"
     
     if [[ $free_disk_space -ge $min_drive_space ]]; then
         echo "   [check_free_space] OK - $free_disk_space GB free/purgeable disk space detected"

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -297,7 +297,7 @@ check_free_space() {
     else
         echo "   [check_free_space] ERROR - $free_disk_space GB free/purgeable disk space detected"
         if [[ -f "$jamfHelper" ]]; then
-            "$jamfHelper" -windowType "utility" -description "${!dialog_check_desc}" -alignDescription "left" -icon "$dialog_confirmation_icon" -button1 "OK" -defaultButton "1" -cancelButton "0"
+            "$jamfHelper" -windowType "utility" -description "${!dialog_check_desc}" -alignDescription "left" -icon "$dialog_confirmation_icon" -button1 "${!dialog_cancel_button}" -defaultButton "1" -cancelButton "0"
         else
             # open_osascript_dialog syntax: title, message, button1, icon
             open_osascript_dialog "${!dialog_check_desc}" "" "OK" stop &

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -271,7 +271,7 @@ ask_for_password() {
 END
     else
         /bin/launchctl asuser "$current_uid" /usr/bin/osascript <<END
-        set nameentry to text returned of (display dialog "${!dialog_get_password} ($account_shortname)" default answer "" with hidden answer buttons {"${!dialog_enter_button}", "${!dialog_cancel_button}"} default button 1 with icon 2)
+        set nameentry to text returned of (display dialog "${!dialog_get_password} ($account_shortname)" default answer "" with hidden answer buttons {"${!dialog_cancel_button}", "${!dialog_enter_button}"} default button 2 with icon 2)
 END
     fi
 }
@@ -279,7 +279,7 @@ END
 ask_for_shortname() {
     # required for Silicon Macs
     /bin/launchctl asuser "$current_uid" /usr/bin/osascript <<END
-        set nameentry to text returned of (display dialog "${!dialog_short_name}" default answer "" buttons {"${!dialog_enter_button}", "${!dialog_cancel_button}"} default button 1 with icon 2)
+        set nameentry to text returned of (display dialog "${!dialog_short_name}" default answer "" buttons {"${!dialog_cancel_button}", "${!dialog_enter_button}"} default button 2 with icon 2)
 END
 }
 
@@ -291,13 +291,14 @@ check_free_space() {
         # fall back to df -h if the above fails
         free_disk_space=$(df -Pk . | column -t | sed 1d | awk '{print $4}')
     fi
+        echo "   [check_free_space] min_drive_space: $free_disk_space vs $min_drive_space"
     
     if [[ $free_disk_space -ge $min_drive_space ]]; then
         echo "   [check_free_space] OK - $free_disk_space GB free/purgeable disk space detected"
     else
         echo "   [check_free_space] ERROR - $free_disk_space GB free/purgeable disk space detected"
         if [[ -f "$jamfHelper" ]]; then
-            "$jamfHelper" -windowType "utility" -description "${!dialog_check_desc}" -alignDescription "left" -icon "$dialog_confirmation_icon" -button1 "OK" -defaultButton "0" -cancelButton "1"
+            "$jamfHelper" -windowType "utility" -description "${!dialog_check_desc}" -alignDescription "left" -icon "$dialog_confirmation_icon" -button1 "OK" -defaultButton "1" -cancelButton "0"
         else
             # open_osascript_dialog syntax: title, message, button1, icon
             open_osascript_dialog "${!dialog_check_desc}" "" "OK" stop &
@@ -604,9 +605,9 @@ confirm() {
         # DEPNotify creates a bom file if the user presses the confirmation button
         # but not if they cancel
         if [[ -f "$depnotify_confirmation_file" ]]; then
-            confirmation=2
-        else
             confirmation=0
+        else
+            confirmation=2
         fi
         # now clear the button, quit key and dialog
         dep_notify_quit
@@ -620,7 +621,7 @@ confirm() {
             jh_title="${!dialog_reinstall_title}"
             jh_desc="${!dialog_reinstall_confirmation_desc}"
         fi
-        "$jamfHelper" -windowType utility -title "$jh_title" -alignHeading center -alignDescription natural -description "$jh_desc" -lockHUD -icon "$dialog_confirmation_icon" -button1 "${!dialog_cancel_button}" -button2 "${!dialog_confirmation_button}" -defaultButton 1 -cancelButton 1 2> /dev/null
+        "$jamfHelper" -windowType utility -title "$jh_title" -alignHeading center -alignDescription natural -description "$jh_desc" -lockHUD -icon "$dialog_confirmation_icon" -button1 "${!dialog_confirmation_button}" -button2 "${!dialog_cancel_button}" -defaultButton 0 -cancelButton 2 2> /dev/null
         confirmation=$?
     else
         # osascript dialog option
@@ -632,19 +633,19 @@ confirm() {
         fi
         answer=$(
             /bin/launchctl asuser "$current_uid" /usr/bin/osascript <<-END
-                set nameentry to button returned of (display dialog "$osa_desc" buttons {"${!dialog_confirmation_button}", "${!dialog_cancel_button}"} default button "${!dialog_cancel_button}" with icon 2)
+                set nameentry to button returned of (display dialog "$osa_desc" buttons {"${!dialog_cancel_button}", "${!dialog_confirmation_button}"} default button "${!dialog_cancel_button}" with icon 2)
 END
 )
         if [[ "$answer" == "${!dialog_confirmation_button}" ]]; then
-            confirmation=2
-        else
             confirmation=0
+        else
+            confirmation=2
         fi
     fi
-    if [[ "$confirmation" == "0"* ]]; then
+    if [[ "$confirmation" == "2"* ]]; then
         echo "   [$script_name] User DECLINED erase-install or reinstall"
         exit 0
-    elif [[ "$confirmation" == "2"* ]]; then
+    elif [[ "$confirmation" == "0"* ]]; then
         echo "   [$script_name] User CONFIRMED erase-install or reinstall"
     else
         echo "   [$script_name] User FAILED to confirm erase-install or reinstall"


### PR DESCRIPTION
Reorder dialogs with more than one button to reflect Apple HID Guide, that means i had to swap values 0 and 2 for the "confirmation" variable.

> "Place buttons where people expect them. In general, the button people are most likely to choose should be on the right. The default button should always be on the right. Cancel buttons are typically on the left."

I think i tested all combinations with --test-run, but of course this PR is purely cosmetical.