### PR TITLE
Convert lonely tabs to spaces

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -994,43 +994,43 @@ get_user_details() {
     while read -r line ; do
         user=$(/usr/bin/cut -d, -f1 <<< "$line")
         guid=$(/usr/bin/cut -d, -f2 <<< "$line")
-		# passwords are case sensitive, account names are not
-		shopt -s nocasematch
+        # passwords are case sensitive, account names are not
+        shopt -s nocasematch
         if [[ $(/usr/bin/grep -A2 "$guid" <<< "$users" | /usr/bin/tail -n1 | /usr/bin/awk '{print $NF}') == "Yes" ]]; then
             enabled_users+="$user "
-			# The entered username might not match the output of fdesetup, so we compare
-			# all RecordNames for the canonical name given by fdesetup against the entered
-			# username, and then use the canonical version. The entered username might
-			# even be the RealName, and we still would end up here.
-			# Example:
-			# RecordNames for user are "John.Doe@pretendco.com" and "John.Doe", fdesetup
-			# says "John.Doe@pretendco.com", and account_shortname is "john.doe" or "Doe, John"
-			user_record_names_xml=$(/usr/bin/dscl -plist /Search -read "Users/$user" RecordName dsAttrTypeStandard:RecordName)
-			# loop through recordName array until error (we do not know the size of the array)
-			record_name_index=0
-			while true; do
-				if ! user_record_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RecordName:${record_name_index}" /dev/stdin 2>/dev/null <<< "$user_record_names_xml") ; then
-				    break
+            # The entered username might not match the output of fdesetup, so we compare
+            # all RecordNames for the canonical name given by fdesetup against the entered
+            # username, and then use the canonical version. The entered username might
+            # even be the RealName, and we still would end up here.
+            # Example:
+            # RecordNames for user are "John.Doe@pretendco.com" and "John.Doe", fdesetup
+            # says "John.Doe@pretendco.com", and account_shortname is "john.doe" or "Doe, John"
+            user_record_names_xml=$(/usr/bin/dscl -plist /Search -read "Users/$user" RecordName dsAttrTypeStandard:RecordName)
+            # loop through recordName array until error (we do not know the size of the array)
+            record_name_index=0
+            while true; do
+                if ! user_record_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RecordName:${record_name_index}" /dev/stdin 2>/dev/null <<< "$user_record_names_xml") ; then
+                    break
                 fi
-				if [[ "$account_shortname" == "$user_record_name" ]]; then
-					account_shortname=$user
-					echo "   [get_user_details] $account_shortname is a Volume Owner"
-					user_is_volume_owner=1
-					break
-				fi
-				record_name_index=$((record_name_index+1))
-			done
-			# if needed, compare the RealName (which might contain spaces)
-			if [[ $user_is_volume_owner = 0 ]]; then
-				user_real_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RealName:0" /dev/stdin <<< "$(/usr/bin/dscl -plist /Search -read "Users/$user" RealName)")
-				if [[ "$account_shortname" == "$user_real_name" ]]; then
-					account_shortname=$user
-					echo "   [get_user_details] $account_shortname is a Volume Owner"
-					user_is_volume_owner=1
-				fi
-			fi
+                if [[ "$account_shortname" == "$user_record_name" ]]; then
+                    account_shortname=$user
+                    echo "   [get_user_details] $account_shortname is a Volume Owner"
+                    user_is_volume_owner=1
+                    break
+                fi
+                record_name_index=$((record_name_index+1))
+            done
+            # if needed, compare the RealName (which might contain spaces)
+            if [[ $user_is_volume_owner = 0 ]]; then
+                user_real_name=$(/usr/libexec/PlistBuddy -c "print :dsAttrTypeStandard\:RealName:0" /dev/stdin <<< "$(/usr/bin/dscl -plist /Search -read "Users/$user" RealName)")
+                if [[ "$account_shortname" == "$user_real_name" ]]; then
+                    account_shortname=$user
+                    echo "   [get_user_details] $account_shortname is a Volume Owner"
+                    user_is_volume_owner=1
+                fi
+            fi
         fi
-		shopt -u nocasematch
+        shopt -u nocasematch
     done <<< "$(/usr/bin/fdesetup list)"
     if [[ $enabled_users != "" && $user_is_volume_owner = 0 ]]; then
         echo "   [get_user_details] $account_shortname is not a Volume Owner"


### PR DESCRIPTION
Another cosmetic issue: i left committed some lines with tabs instead of spaces. This PR properly converts them back to 4 spaces to be consistent with the rest of the script. 