### PR TITLE
Fix for issue #242: re-check free space after download stage

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -2071,6 +2071,9 @@ if [[ $erase != "yes" && $reinstall != "yes" ]]; then
     exit
 fi
 
+# re-check if there is enough space after a possible installer download
+check_free_space
+
 ## Steps beyond here are to run startosinstall
 
 echo


### PR DESCRIPTION
Simply re-check the free space once more right before starting the installation (after the downloading/cleaning stage is complete) to prevent problems with installation due to insufficient disk space, and checking twice probably doesn't hurt because the user can fill up the disk working on stuff while the installer is being downloaded. 
This should address issue #242, but i haven't done any testing for edge cases.