### PR TITLE
Allow rebootdelay for macOS 10.15

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -2172,8 +2172,8 @@ if [[ $installer_darwin_version -ge 20 ]]; then
     install_args+=("--allowremoval")
 fi
 
-# macOS 11 (Darwin 20) and above can use the --rebootdelay option
-if [[ $installer_darwin_version -ge 20 && "$rebootdelay" -gt 0 ]]; then
+# macOS 10.15 (Darwin 19) and above can use the --rebootdelay option
+if [[ $installer_darwin_version -ge 19 && "$rebootdelay" -gt 0 ]]; then
     install_args+=("--rebootdelay")
     install_args+=("$rebootdelay")
 else


### PR DESCRIPTION
rebootdelay works for me with 10.15.3 installer. Apparently startosinstall from 10.13 and 10.14 also supports this parameter, but i haven't done a full test with it (just downloaded using installinstallmacos and did a startosinstall -h).

Perhaps there's a reason why 10.15 has been excluded, but it worked for me now to upgrade 10.15 to macOS 12.