### PR TITLE
Passthrough --newvolumename to OS installer

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1756,7 +1756,7 @@ while test $# -gt 0 ; do
             shift
             prechosen_os="$1"
             ;;
-        --newvolumename) renamevolume="yes"
+        --newvolumename) rename_volume="yes"
             shift
             newvolumename="$1"
             ;;
@@ -2193,7 +2193,7 @@ if [[  $installer_darwin_version -ge 19 ]]; then
 fi
 
 # pass new volume name if specified
-if [[ $erase == "yes" && "$renamevolume" == "yes" ]]; then
+if [[ $erase == "yes" && "$rename_volume" == "yes" ]]; then
     install_args+=("--newvolumename")
     install_args+=("$newvolumename")
 fi

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1475,6 +1475,8 @@ show_help() {
     --path /path/to     Overrides the destination of --move to a specified directory
     --erase             After download, erases the current system
                         and reinstalls macOS.
+    --newvolumename     If using the --erase option, lets you customize the name of the
+                        clean volume. Default is 'Macintosh HD'.
     --confirm           Displays a confirmation dialog prior to erasing the current
                         system and reinstalling macOS. 
     --depnotify         Uses DEPNotify for dialogs instead of jamfHelper, if installed.
@@ -1753,6 +1755,10 @@ while test $# -gt 0 ; do
         --os)
             shift
             prechosen_os="$1"
+            ;;
+        --newvolumename) renamevolume="yes"
+            shift
+            newvolumename="$1"
             ;;
         --version)
             shift
@@ -2184,6 +2190,12 @@ fi
 # macOS 10.15 (Darwin 19) and above requires the --forcequitapps options
 if [[  $installer_darwin_version -ge 19 ]]; then    
     install_args+=("--forcequitapps")
+fi
+
+# pass new volume name if specified
+if [[ $erase == "yes" && "$renamevolume" == "yes" ]]; then
+    install_args+=("--newvolumename")
+    install_args+=("$newvolumename")
 fi
 
 # icons for Jamf Helper erase and re-install windows

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1756,7 +1756,7 @@ while test $# -gt 0 ; do
             shift
             prechosen_os="$1"
             ;;
-        --newvolumename) rename_volume="yes"
+        --newvolumename)
             shift
             newvolumename="$1"
             ;;
@@ -2193,7 +2193,7 @@ if [[  $installer_darwin_version -ge 19 ]]; then
 fi
 
 # pass new volume name if specified
-if [[ $erase == "yes" && "$rename_volume" == "yes" ]]; then
+if [[ $erase == "yes" && $newvolumename ]]; then
     install_args+=("--newvolumename")
     install_args+=("$newvolumename")
 fi


### PR DESCRIPTION
These changes add a new flag to `erase-install`: **--newvolumename**

Passes through the option of the same name to `startosinstall`, to optionally allow setting the name of the post-erase macOS boot volume.