### PR TITLE
Update erase-install.sh

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1918,6 +1918,10 @@ fi
 # Look for the installer, download it if it is not present
 echo "   [$script_name] Looking for existing installer app or pkg"
 find_existing_installer
+if [[ "$prechosen_build" != "" && "$installer_build" != "" ]]; then
+  # compare build of found installer to what we choose
+  compare_build_versions "$prechosen_build" "$installer_build"
+fi
 
 if [[ $invalid_installer_found == "yes" && -d "$working_macos_app" && $replace_invalid_installer == "yes" ]]; then
     overwrite_existing_installer


### PR DESCRIPTION
this needs some checking and extra help - but i was finding in my environment, erase-install was downloading the installer over and over again even if the installer present was valid and matched what i wanted. I tracked things down and it seems the `compare_build_versions` function is only called to compare the system version to the installer. I threw in a test to see if we are specifying a build version and called the function again to compare the found installer to what we are choosing.

i think this is valid and will work correctly and it does in my test. more logic would have to be put in for version check of a found installer as well.