### PR TITLE
check_installer_is_valid

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -371,7 +371,7 @@ check_installer_is_valid() {
     fi
     if [[ ! $installer_build ]]; then
         echo "   [check_installer_is_valid] Build of existing installer could not be found!"
-        exit 1
+        #exit 1
     fi
 
     system_build=$( /usr/bin/sw_vers -buildVersion )

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -714,7 +714,6 @@ dep_notify_progress() {
     current_progress_value=0
 
     if [[ "$1" == "startosinstall" ]]; then
-        echo "Status: UNDERGOING TEST" >> $depnotify_log # TEMP
         # Wait for the preparing process to start and set the progress bar to 100 steps
         until grep -q "Preparing: \d" "$LOG_FILE" ; do
             sleep 2


### PR DESCRIPTION
`check_installer_is_valid`: dont exit if existing installer is broken. this allows the script to possibly get a new installer later.

looking at the code and where this function is called, i do not believe we want to do a hard error exit if the installer found cannot be verified. logic in the calling portion of the script is then able to resolve this bad installer by replacing.

to be more thorough should we be setting:
`invalid_installer_found="yes"`

as is though commenting out the exit it seems to function as expected.

test case that brought this to my attention was a sparsebundle that was incomplete.