### PR TITLE
also return error codes when we get interrupted or terminated

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -830,10 +830,18 @@ find_extra_packages() {
 }
 
 # -----------------------------------------------------------------------------
+# Return code 143 and finish the script when TERMinated or INTerrupted
+# -----------------------------------------------------------------------------
+terminate() {
+    echo "   [terminate] Script was interrupted (last exit code was $?)"
+    exit 143
+}
+
+# -----------------------------------------------------------------------------
 # Things to carry out when the script exits
 # -----------------------------------------------------------------------------
 finish() {
-    local exit_code=$?
+    local exit_code=${1:-$?}
     # if we promoted the user then we should demote it again
     if [[ $promoted_user ]]; then
         /usr/sbin/dseditgroup -o edit -d "$promoted_user" admin
@@ -2031,6 +2039,9 @@ user_not_volume_owner() {
 
 # ensure the finish function is executed when exit is signaled
 trap "finish" EXIT
+
+# ensure the finish function is executed and an error code is returned when the script is TERMinated or INTerrupted
+trap "terminate" SIGINT SIGTERM
 
 # ensure some cleanup is done after startosinstall is run (thanks @frogor!)
 trap "post_prep_work" SIGUSR1  # 30 is the numerical representation of SIGUSR1 (thanks @n8felton)


### PR DESCRIPTION
This change will cause erase-install to report a non-zero exit code (143 to be exact) when it is being abnormally terminated (e.g. by pressing CTRL+C or getting terminated by SIGTERM).

Previously it would return the exit code of the last command being executed at time of termination, which could be non-zero or zero depending on the specific circumstances, which then could have been reported as successful execution in a Jamf policy.

This change will make it easier to discover such errors. The exit code of the last executed command will be logged in addition to returning 143 to facilitate debugging.