### PR TITLE
27.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 No date
 
+## [27.3]
+
+24.01.2023
+
+- (change to `installinstallmacos.py`): version comparisons are now done with the python module `packaging.version.LegacyVersion`, as `parse_version` proved unreliable.
+
 ## [27.2]
 
 14.12.2022

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -49,7 +49,7 @@ version="27.3"
 # installinstallmacos.py if not using the recommended package installer
 # This is calculated with: shasum -a 256 installinstallmacos.py | cut -d' ' -f1
 installinstallmacos_url="https://raw.githubusercontent.com/grahampugh/macadmin-scripts/v${version}/installinstallmacos.py"
-installinstallmacos_checksum="f224691912e8d50f2ab542b269b7371e0e0f9b646dcef0ffda7769bab2bc2049"
+installinstallmacos_checksum="084fc6c563830467105feb7d8960f8ae77eacee0b28ecbfa7ced304118666ac1"
 
 # Directory in which to place the macOS installer. Overridden with --path
 installer_directory="/Applications"

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -41,14 +41,15 @@ script_name="erase-install"
 pkg_label="com.github.grahampugh.erase-install"
 
 # Version of this script
-version="27.2"
+version="27.3"
 
 # URL for downloading installinstallmacos.py
 # The tag and checksum of the macadmin-scripts fork is updated to match the version 
 # of erase-install. This adds a bit of security to the curl download of
 # installinstallmacos.py if not using the recommended package installer
+# This is calculated with: shasum -a 256 installinstallmacos.py | cut -d' ' -f1
 installinstallmacos_url="https://raw.githubusercontent.com/grahampugh/macadmin-scripts/v${version}/installinstallmacos.py"
-installinstallmacos_checksum="8285cfb5c436954dfad39303c6478b5f8dff2082911df4fde2681a295a53fdff"
+installinstallmacos_checksum="f224691912e8d50f2ab542b269b7371e0e0f9b646dcef0ffda7769bab2bc2049"
 
 # Directory in which to place the macOS installer. Overridden with --path
 installer_directory="/Applications"

--- a/pkg/erase-install-depnotify/build-info.plist
+++ b/pkg/erase-install-depnotify/build-info.plist
@@ -17,6 +17,6 @@
         <key>suppress_bundle_relocation</key>
         <true/>
         <key>version</key>
-        <string>27.2</string>
+        <string>27.3</string>
     </dict>
 </plist>

--- a/pkg/erase-install-nopython/build-info.plist
+++ b/pkg/erase-install-nopython/build-info.plist
@@ -17,6 +17,6 @@
         <key>suppress_bundle_relocation</key>
         <true/>
         <key>version</key>
-        <string>27.2</string>
+        <string>27.3</string>
     </dict>
 </plist>

--- a/pkg/erase-install/build-info.plist
+++ b/pkg/erase-install/build-info.plist
@@ -17,6 +17,6 @@
         <key>suppress_bundle_relocation</key>
         <true/>
         <key>version</key>
-        <string>27.2</string>
+        <string>27.3</string>
     </dict>
 </plist>


### PR DESCRIPTION
- (change to `installinstallmacos.py`): version comparisons are now done with the python module `packaging.version.LegacyVersion`, as `parse_version` proved unreliable.
