### PR TITLE
Fix for installation at login screen

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1277,6 +1277,12 @@ get_user_details() {
                 writelog "[get_user_details] ERROR: Supplied credentials are in the incorrect form, so exiting..."
                 exit 1
             fi
+        elif ! pgrep -q Finder ; then
+            writelog "[get_user_details] ERROR! The startosinstall binary requires a user to be logged in."
+            echo
+            # kill caffeinate
+            kill_process "caffeinate"
+            exit 1
         elif [[ ! $silent ]]; then
             ask_for_credentials
             if [[ $? -eq 2 ]]; then
@@ -3112,19 +3118,12 @@ elif [[ $invalid_installer_found == "yes" ]]; then
 fi
 
 # Silicon Macs require a username and password to run startosinstall
-# We therefore need to be logged in to proceed, if we are going to erase or reinstall
+# We therefore need credentials to proceed, if we are going to erase or reinstall
 # This goes before the download so users aren't waiting for the prompt for username
 # Check for Apple Silicon using sysctl, because arch will not report arm64 if running under Rosetta.
 [[ $(/usr/sbin/sysctl -q -n "hw.optional.arm64") -eq 1 ]] && arch="arm64" || arch=$(/usr/bin/arch)
 writelog "[$script_name] Running on architecture $arch"
 if [[ "$arch" == "arm64" && ($erase == "yes" || $reinstall == "yes") ]]; then
-    if ! pgrep -q Finder ; then
-        writelog "[$script_name] ERROR! The startosinstall binary requires a user to be logged in."
-        echo
-        # kill caffeinate
-        kill_process "caffeinate"
-        exit 1
-    fi
     get_user_details
 fi
 


### PR DESCRIPTION
This allows installation to proceed on an Apple Silicon machine if no user is signed in as long as there's proper credentials provided via keychain or base64.

I know officially the scenario is unsupported but it worked for me with the keychain option and the changes incorporated. This is important to me because I'd like to add a deadline when running this script via Munki, and the behavior of Munki if a deadline is reached is to force log out the user and install all pending updates at the login screen.