### PR TITLE
Disk space check for download-only runs

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -414,7 +414,7 @@ check_free_space() {
     # if there isn't enough space, then we show a failure message to the user
     if [[ $free_disk_space -ge $min_drive_space ]]; then
         writelog "[check_free_space] OK - $free_disk_space GB free/purgeable disk space detected"
-    elif [[ $silent ]]; then
+    elif [[ $silent || ($erase != "yes" && $reinstall != "yes") ]]; then
         writelog "[check_free_space] ERROR - $free_disk_space GB free/purgeable disk space detected"
         echo
         exit 1
@@ -2461,6 +2461,16 @@ download_install_assistant_pkg() {
                 exit 1
             fi
             writelog "[download_install_assistant_pkg] Found InstallAssistant.pkg for latest version at $installer_url"
+        fi
+    fi
+
+    # check for free disk space if not invoking erase or reinstall options
+    if [[ $erase != "yes" && $reinstall != "yes" ]]; then
+        installer_size=$(curl -sI "$installer_url" | awk '/^Content-Length:/ {print $2}' | tr -d $'\r')
+        if [[ $installer_size ]]; then
+            min_drive_space=$((installer_size / 1000000000 + 1))
+            writelog "[download_install_assistant_pkg] $min_drive_space GB disk space required to download"
+            check_free_space
         fi
     fi
 


### PR DESCRIPTION
Adds a disk space check before downloading the installer if startosinstall isn't being run and `--native` is being used. Here is the end of the output from running `/Library/Management/erase-install/erase-install.sh --native --update` on a computer with low disk space:

```
2025-11-19 15:11:13 | v39.1 | [download_install_assistant_pkg] No version or OS selected, obtaining the latest compatible InstallAssistant.pkg
2025-11-19 15:11:13 | v39.1 | [download_install_assistant_pkg] Found InstallAssistant.pkg for latest compatible version at https://swcdn.apple.com/content/downloads/60/34/089-04325-A_JAKF079NR4/fjimp3su7pvbg0o6sf3kus7k989finz274/InstallAssistant.pkg
2025-11-19 15:11:13 | v39.1 | [download_install_assistant_pkg] 18 GB disk space required to download
2025-11-19 15:11:14 | v39.1 | [check_free_space] ERROR - 9 GB free/purgeable disk space detected


2025-11-19 15:11:14 | v39.1 | [erase-install] terminating the process 'caffeinate' process

2025-11-19 15:11:14 | v39.1 | [finish] sending quit message to dialog (/var/tmp/dialog.ozC)
2025-11-19 15:11:14 | v39.1 | [finish] Script exit code: 1
```