### PR TITLE
Fix German localization for Find My Mac message

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -3227,7 +3227,7 @@ set_localisations() {
 
     # Dialogue localizations - Find My check failed - description
     dialog_fmmenabled_desc_en="### Find My Mac was not disabled in the specified time.  \n\nPress OK to quit."
-    dialog_fmmenabled_desc_de="### «Meinem Mac suchen» wurde nicht innerhalb der angegebenen Zeit deaktiviert.  \n\nZum Beenden OK drücken."
+    dialog_fmmenabled_desc_de="### «Meinen Mac suchen» wurde nicht innerhalb der angegebenen Zeit deaktiviert.  \n\nZum Beenden OK drücken."
     dialog_fmmenabled_desc_nl="### Vind mijn Mac was niet uitgeschakeld in de opgegeven tijd.  \n\nDruk op OK om af te sluiten."
     dialog_fmmenabled_desc_fr="### Localiser mon Mac n'a pas été désactivé dans le temps imparti.  \n\nAppuyez sur OK pour quitter."
     dialog_fmmenabled_desc_es="### Buscar mi Mac no se ha desactivado en el tiempo especificado.  \n\nPulsa OK para salir."


### PR DESCRIPTION
Change from "Meinem Mac suchen" to  "Meinen Mac suchen"