### PR TITLE
Patch Script - erase-install.sh - SwiftDialog Check

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -4,6 +4,7 @@
 # this is to use sed in the case statements
 # shellcheck disable=SC2034,SC2296
 # these are due to the dynamic variable assignments used in the localization strings
+# set -x
 
 : <<DOC
 ==============================================================================
@@ -270,6 +271,7 @@ check_for_mist() {
 # Download dialog if not present and not --silent mode
 # -----------------------------------------------------------------------------
 check_for_swiftdialog_app() {
+    system_version="14.7.8"
     # swiftDialog 3.0 is compatible with macOS 15+. Remove this version if present on older OSs
     if [[ -d "$dialog_portable_app" ]]; then
         dialog_bin="$dialog_portable_app/Contents/MacOS/dialogcli"
@@ -298,8 +300,8 @@ check_for_swiftdialog_app() {
     else
         writelog "[check_for_swiftdialog_app] swiftDialog v$dialog_string is installed but the recommended version is $swiftdialog_tag_required."
         if [[ ! $no_curl ]]; then
-            if ! is-at-least "11" "$system_version"; then
-                writelog "[check_for_swiftdialog_app] Downloading swiftDialog for macOS $system_version..."
+            if is-at-least "11" "$system_version"; then
+                writelog "[check_for_swiftdialog_app] Downloading swiftDialog $swiftdialog_tag_required for macOS $system_version..."
                 # obtain the download URL
                 swiftdialog_api_url="https://api.github.com/repos/swiftDialog/swiftDialog/releases"
                 dialog_download_url=$(/usr/bin/curl -sL -H "Accept: application/json" "$swiftdialog_api_url/tags/$swiftdialog_tag_required" | ljt assets.0.browser_download_url -)

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -4,7 +4,6 @@
 # this is to use sed in the case statements
 # shellcheck disable=SC2034,SC2296
 # these are due to the dynamic variable assignments used in the localization strings
-# set -x
 
 : <<DOC
 ==============================================================================

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -270,7 +270,6 @@ check_for_mist() {
 # Download dialog if not present and not --silent mode
 # -----------------------------------------------------------------------------
 check_for_swiftdialog_app() {
-    system_version="14.7.8"
     # swiftDialog 3.0 is compatible with macOS 15+. Remove this version if present on older OSs
     if [[ -d "$dialog_portable_app" ]]; then
         dialog_bin="$dialog_portable_app/Contents/MacOS/dialogcli"


### PR DESCRIPTION
What's new:

SwiftDialog Version Handling:

* Fixed the logic for downloading SwiftDialog: now, the script will attempt to download SwiftDialog only if the system version is at least 11, correcting the previous inverted condition. The log message was also updated to include the required tag and system version.
* Previously, it would only download it if it wasn't installed and the version was less than 11.

Logs before change:
```
% curl -s https://raw.githubusercontent.com/grahampugh/erase-install/release/erase-install.sh | sudo zsh /dev/stdin /Library/Management/erase-install/erase-install.sh --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150
2026-04-02 20:26:18 | v42.1 | [erase-install] Making working directory at /Library/Management/erase-install
2026-04-02 20:26:18 | v42.1 | [erase-install] Making log directory at /Library/Management/erase-install/log
2026-04-02 20:26:18 | v42.1 | [log_rotate] Finished rotating logs in /Library/Management/erase-install/log
2026-04-02 20:26:18 | v42.1 | [erase-install] v42.1 script execution started: Thu Apr  2 20:26:18 CST 2026
2026-04-02 20:26:18 | v42.1 | [erase-install] Arguments provided: /Library/Management/erase-install/erase-install.sh --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150
2026-04-02 20:26:18 | v42.1 | [set_localisations] Set language to en-MX
2026-04-02 20:26:18 | v42.1 | [erase-install] System version: 15.7.2 (Build: 24G325)
2026-04-02 20:26:20 | v42.1 | [check_for_swiftdialog_app] swiftDialog v is installed but the recommended version is v3.0.1.
2026-04-02 20:26:20 | v42.1 | [check_for_swiftdialog_app] swiftDialog is not compatible with macOS 15.7.2, so it will not be downloaded. Silent mode is required for use on macOS 10.15, so no dialog will be used on that version of macOS.
2026-04-02 20:26:20 | v42.1 | [check_for_swiftdialog_app] ERROR: Could not download swiftDialog.
2026-04-02 20:26:20 | v42.1 | [finish] sending quit message to dialog (/var/tmp/dialog.wtg)
2026-04-02 20:26:20 | v42.1 | [finish] Script exit code: 1
```
Logs after change:

```
% sudo "/Users/hlws/Documents/Github/erase-install/erase-install.sh" --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150

2026-04-02 20:40:30 | v42.1 | [log_rotate] Finished rotating logs in /Library/Management/erase-install/log
2026-04-02 20:40:30 | v42.1 | [erase-install] v42.1 script execution started: Thu Apr  2 20:40:30 CST 2026
2026-04-02 20:40:30 | v42.1 | [erase-install] Arguments provided: --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150
2026-04-02 20:40:30 | v42.1 | [set_localisations] Set language to en-MX
2026-04-02 20:40:30 | v42.1 | [erase-install] System version: 15.7.2 (Build: 24G325)
2026-04-02 20:40:30 | v42.1 | [check_for_swiftdialog_app] swiftDialog v is installed but the recommended version is v3.0.1.
2026-04-02 20:40:30 | v42.1 | [check_for_swiftdialog_app] Downloading swiftDialog v3.0.1 for macOS 15.7.2...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  2 16.2M    2  367k    0     0   335k      0  0:00:49  0:00:01  0:00:48  335k^C2026-04-02 20:40:32 | v42.1 | [terminate] Script was interrupted (last exit code was 130)
2026-04-02 20:40:32 | v42.1 | [finish] sending quit message to dialog (/var/tmp/dialog.kZA)
2026-04-02 20:40:33 | v42.1 | [finish] Script exit code: 143
```

Logs after change (hardcoded system_version to 14.7.8):
```
% sudo "/Users/hlws/Documents/Github/erase-install/erase-install.sh" --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150
2026-04-02 20:51:39 | v42.1 | [log_rotate] Finished rotating logs in /Library/Management/erase-install/log
2026-04-02 20:51:39 | v42.1 | [erase-install] v42.1 script execution started: Thu Apr  2 20:51:39 CST 2026
2026-04-02 20:51:39 | v42.1 | [erase-install] Arguments provided: --reinstall --version=26.4 --update --mist --min-drive-space=40 --current-user --check-power --no-fs --cleanup-after-use --rebootdelay 150
2026-04-02 20:51:39 | v42.1 | [set_localisations] Set language to en-MX
2026-04-02 20:51:39 | v42.1 | [erase-install] System version: 15.7.2 (Build: 24G325)
2026-04-02 20:51:39 | v42.1 | [check_for_swiftdialog_app] swiftDialog v is installed but the recommended version is v2.2.1.
2026-04-02 20:51:39 | v42.1 | [check_for_swiftdialog_app] Downloading swiftDialog v2.2.1 for macOS 14.7.8...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
^C2026-04-02 20:51:41 | v42.1 | [terminate] Script was interrupted (last exit code was 130)
2026-04-02 20:51:41 | v42.1 | [finish] sending quit message to dialog (/var/tmp/dialog.KZG)
2026-04-02 20:51:41 | v42.1 | [finish] Script exit code: 143
```