### PR TITLE
Upgrade to version 42.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,21 +22,22 @@ I have deleted previous beta releases that don't make it to be a latest release.
 
 No date
 
-## [42.2]
+## [42.3]
 
 No date
 
-### Updates in 42.2
+### Updates in 42.3
 
 - Bumped required swiftDialog version to `v3.0.1` except for systems running macOS 14 or older which still get `v2.2.1`. Note that the installer package includes both version `v3.0.1` and `v2.2.1`, and the appropriate one will be installed.
 - swiftDialog check is only made when required, meaning that the `--list` and `--download` (without `--dialog-on-download`) options will work without swiftDialog.
 - If swiftDialog is reqiured but missing from the workdir, for example if only using the script rather than the package, then install the appropriate version of swiftDialog for the OS into the workdir rather than the default location.
 
-### Bugfixes in 42.2
+### Bugfixes in 42.3
 
 - Fixed check for swiftDialog version on macOS 14 (addresses #586).
 - Fixed check for swiftDialog version on macOS 15+ that was introduced in 42.1.
 - Banner is not used when swiftDialog 2.2.1 is used (incompatible dialog arguments).
+- Fixed installing older version of swiftDialog over a newer version (also addresses a comment in #586).
 
 ## [41.1]
 
@@ -838,7 +839,6 @@ Thanks to '@ahousseini' for various contributions to this release
 - Initial version. Expects a manual choice of installer from `installinstallmacos.py`.
 
 [untagged]: https://github.com/grahampugh/erase-install/compare/v42.2...HEAD
-[42.0]: https://github.com/grahampugh/erase-install/compare/v41.1...v42.2
 [41.1]: https://github.com/grahampugh/erase-install/compare/v40.4...v41.1
 [40.4]: https://github.com/grahampugh/erase-install/compare/v39.1...v40.4
 [39.1]: https://github.com/grahampugh/erase-install/compare/v39.0...v39.1

--- a/erase-install.sh
+++ b/erase-install.sh
@@ -39,7 +39,7 @@ script_name="erase-install"
 pkg_label="com.github.grahampugh.erase-install"
 
 # Version of this script
-version="42.2"
+version="42.3"
 
 # Directory in which to place the macOS installer. Overridden with --path
 installer_directory="/Applications"
@@ -295,6 +295,7 @@ check_for_swiftdialog_app() {
     else
         if [[ -f "$dialog_bin" ]]; then
             writelog "[check_for_swiftdialog_app] swiftDialog v$dialog_string is installed but the recommended version is $swiftdialog_tag_required."
+            /bin/rm -rf "$dialog_portable_app"
         else
             writelog "[check_for_swiftdialog_app] swiftDialog is not installed. Proceeding to install..."
         fi


### PR DESCRIPTION
Update the required swiftDialog version and improve installation logic. Fix bugs related to swiftDialog checks on macOS 14 and 15+, and ensure proper handling of swiftDialog versions during installation. Address issues raised in previous comments.