### PR TITLE
Show macOShow macOS version in native download progress dialog

### DIFF
--- a/erase-install.sh
+++ b/erase-install.sh
@@ -1091,6 +1091,13 @@ dialog_progress() {
     elif [[ "$1" == "native" ]]; then
         writelog "[dialog_progress] Sending to dialog: progresstext: Searching for a valid macOS installer..."
         echo "progresstext: Searching for a valid macOS installer..." >> "$dialog_log"
+        # ia_version/ia_build are resolved by get_install_assistant_pkg_details()
+        # before this process was forked, so they're already available here
+        if [[ -n "$ia_version" ]]; then
+            dialog_download_message="Downloading macOS $ia_version${ia_build:+ ($ia_build)}"
+        else
+            dialog_download_message="Downloading InstallAssistant.pkg"
+        fi
         # Wait for the download to start and set the progress bar to 100 steps
         # this needs to monitor the output of curl
         until grep -q "Found InstallAssistant.pkg" "$LOG_FILE" ; do
@@ -1100,8 +1107,8 @@ dialog_progress() {
         until grep -q "Downloading InstallAssistant.pkg" "$LOG_FILE" ; do
             sleep 2
         done
-        writelog "[dialog_progress] Sending to dialog: progresstext: Downloading InstallAssistant.pkg"
-        echo "progresstext: Downloading InstallAssistant.pkg" >> "$dialog_log"
+        writelog "[dialog_progress] Sending to dialog: progresstext: $dialog_download_message"
+        echo "progresstext: $dialog_download_message" >> "$dialog_log"
         echo "progress: 0" >> "$dialog_log"
         # Until at least 100% is reached, calculate the downloading progress and move the bar accordingly
         until [[ "$current_progress_value" -ge 100 ]]; do
@@ -1125,7 +1132,7 @@ dialog_progress() {
                 fi
                 sleep 0.5
             done
-            echo "progresstext: Downloading InstallAssistant.pkg ($current_progress_int%)" >> "$dialog_log"
+            echo "progresstext: $dialog_download_message ($current_progress_int%)" >> "$dialog_log"
             echo "progress: $current_progress_int" >> "$dialog_log"
             last_progress_value=$current_progress_value
         done
@@ -1174,9 +1181,13 @@ dialog_progress() {
 }
 
 # -----------------------------------------------------------------------------
-# Download the appropriate InstallAssistant.pkg for the chosen options
+# Work out which InstallAssistant.pkg we need (URL, version, build) based on
+# the chosen options. This is split out from download_install_assistant_pkg()
+# so that ia_version/ia_build are resolved *before* dialog_progress is forked,
+# letting the progress dialog show the actual macOS version being downloaded
+# instead of scraping the log for it.
 # -----------------------------------------------------------------------------
-download_install_assistant_pkg() {
+get_install_assistant_pkg_details() {
     # first, if we didn't already check for updates, get the list of available installers using list_installers_json
     list_installers_from_json
 
@@ -1375,21 +1386,28 @@ download_install_assistant_pkg() {
         fi
     fi
 
+    # get the version and build from $latest_installer so dialog_progress can
+    # use them before the download itself starts
+    ia_version=$("$jq_bin" -r ".version" <<< "$latest_installer")
+    ia_build=$("$jq_bin" -r ".build" <<< "$latest_installer")
+
     # check for free disk space if not invoking erase or reinstall options
     if [[ $erase != "yes" && $reinstall != "yes" ]]; then
         installer_size=$(curl -sI "$installer_url" | awk '/^Content-Length:/ {print $2}' | tr -d $'\r')
         if [[ $installer_size ]]; then
             min_drive_space=$((installer_size / 1000000000 + 1))
-            writelog "[download_install_assistant_pkg] $min_drive_space GB disk space required to download"
+            writelog "[get_install_assistant_pkg_details] $min_drive_space GB disk space required to download"
             check_free_space
         fi
     fi
+}
 
+# -----------------------------------------------------------------------------
+# Download the InstallAssistant.pkg resolved by get_install_assistant_pkg_details().
+# -----------------------------------------------------------------------------
+download_install_assistant_pkg() {
     # now download the installer
     writelog "[download_install_assistant_pkg] Downloading InstallAssistant.pkg from $installer_url"
-    # get the version and build from $latest_installer
-    ia_version=$("$jq_bin" -r ".version" <<< "$latest_installer")
-    ia_build=$("$jq_bin" -r ".build" <<< "$latest_installer")
     trap 'rm -f "$tmpcurlfile"' EXIT
     # writelog "[download_install_assistant_pkg] tmpcurlfile created at $tmpcurlfile" # debug
     # download the installer
@@ -4319,6 +4337,9 @@ if [[ ! -d "$working_macos_app" && ! -f "$working_installer_pkg" ]]; then
         if [[ $ffi == "yes" ]]; then
             dialog_progress fetch-full-installer >/dev/null 2>&1 &
         elif [[ $native == "yes" ]]; then
+            # resolve which macOS version/build we're downloading *before*
+            # forking the progress dialog, so it can show the real version
+            get_install_assistant_pkg_details
             dialog_progress native >/dev/null 2>&1 &
         else
             dialog_progress mist >/dev/null 2>&1 &


### PR DESCRIPTION
Closes #597 - shows the actual macOS version in the "Downloading" progress dialog for the native (non-mist) download path, instead of the generic "Downloading InstallAssistant.pkg".

## Why

`dialog_progress native` is forked into the background *before* `ia_version`/`ia_build` are resolved (that happened later, inside `download_install_assistant_pkg`). Since a child process can't see anything the parent sets after the fork, the only way to get the version into the dialog was to scrape it back out of the log - which is what the original FR proposed, but Graham (rightly) preferred using the existing variable instead.

To do that properly, the fork order needs to flip: resolve the version *before* forking the dialog, not after.

## What changed

1. Split `download_install_assistant_pkg()` into two functions:
   - `get_install_assistant_pkg_details()` - the "which installer do we want" step (list lookup, jq selection, free disk space check), now also resolving `ia_version`/`ia_build`.
   - `download_install_assistant_pkg()` - just the curl download + validation, using whatever `get_install_assistant_pkg_details()` already resolved.
2. Call `get_install_assistant_pkg_details()` before `dialog_progress native &` is forked, so the fork inherits `ia_version`/`ia_build` for free.
3. `dialog_progress()`'s native branch now builds the message from those variables directly ("Downloading macOS 15.6.1 (24G84)"), falling back to the old generic text if for some reason they're not set. It still watches the log to know *when* the download starts - just not to figure out what to say.

## Testing

- `zsh -n erase-install.sh` passes.
- Not yet tested end-to-end on a real Mac with `--native` - happy to do that before merge, or if a maintainer/tester can confirm the dialog text looks right in practice, that'd be great too.

## One thing worth double-checking

Today the dialog shows "Searching for a valid macOS installer..." immediately when the download step starts, while the list lookup runs in parallel. With this change, that lookup now runs *before* the dialog is forked, so there could be a brief pause before anything appears, if `list_installers_from_json` at that point involves a fresh network call rather than reading an already-cached file. Didn't want to assume either way - flagging it here in case it's worth a second look.

---

*Drafted with AI assistance (Claude) and reviewed/tested by before submitting. the only thing i couldnt see was the actual swift dialog window popping up *